### PR TITLE
Fix OCI versioning

### DIFF
--- a/templates/assembly-script/.github/workflows/release.azurecr.yml
+++ b/templates/assembly-script/.github/workflows/release.azurecr.yml
@@ -26,11 +26,11 @@ jobs:
     - name: Set the release version (tag)
       if: startsWith(github.ref, 'refs/tags/v')
       shell: bash
-      run: echo "name=RELEASE_VERSION::${GITHUB_REF/refs\/tags\//}" >> $GITHUB_ENV
+      run: echo "RELEASE_VERSION=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_ENV
     - name: Set the release version (main)
       if: github.ref == 'refs/heads/main'
       shell: bash
-      run: echo "name=RELEASE_VERSION::canary" >> $GITHUB_ENV
+      run: echo "RELEASE_VERSION=canary" >> $GITHUB_ENV
 
     - name: Build release
       run: |
@@ -57,10 +57,10 @@ jobs:
 
     - name: Set the release version
       if: startsWith(github.ref, 'refs/tags/v')
-      run: echo "name=RELEASE_VERSION::${GITHUB_REF/refs\/tags\//}" >> $GITHUB_ENV
+      run: echo "RELEASE_VERSION=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_ENV
     - name: Set the release version
       if: github.ref == 'refs/heads/main'
-      run: echo "name=RELEASE_VERSION::canary" >> $GITHUB_ENV
+      run: echo "RELEASE_VERSION=canary" >> $GITHUB_ENV
 
     - name: Download release assets
       uses: actions/download-artifact@v1

--- a/templates/assembly-script/.github/workflows/release.yml
+++ b/templates/assembly-script/.github/workflows/release.yml
@@ -23,11 +23,11 @@ jobs:
     - name: Set the release version (tag)
       if: startsWith(github.ref, 'refs/tags/v')
       shell: bash
-      run: echo "name=RELEASE_VERSION::${GITHUB_REF/refs\/tags\//}" >> $GITHUB_ENV
+      run: echo "RELEASE_VERSION=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_ENV
     - name: Set the release version (main)
       if: github.ref == 'refs/heads/main'
       shell: bash
-      run: echo "name=RELEASE_VERSION::canary" >> $GITHUB_ENV
+      run: echo "RELEASE_VERSION=canary" >> $GITHUB_ENV
 
     - name: Build release
       run: |
@@ -54,10 +54,10 @@ jobs:
 
     - name: Set the release version
       if: startsWith(github.ref, 'refs/tags/v')
-      run: echo "name=RELEASE_VERSION::${GITHUB_REF/refs\/tags\//}" >> $GITHUB_ENV
+      run: echo "RELEASE_VERSION=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_ENV
     - name: Set the release version
       if: github.ref == 'refs/heads/main'
-      run: echo "name=RELEASE_VERSION::canary" >> $GITHUB_ENV
+      run: echo "RELEASE_VERSION=canary" >> $GITHUB_ENV
 
     - name: Download release assets
       uses: actions/download-artifact@v1

--- a/templates/c/.github/workflows/release.azurecr.yml
+++ b/templates/c/.github/workflows/release.azurecr.yml
@@ -32,11 +32,11 @@ jobs:
     - name: Set the release version (tag)
       if: startsWith(github.ref, 'refs/tags/v')
       shell: bash
-      run: echo "name=RELEASE_VERSION::${GITHUB_REF/refs\/tags\//}" >> $GITHUB_ENV
+      run: echo "RELEASE_VERSION=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_ENV
     - name: Set the release version (main)
       if: github.ref == 'refs/heads/main'
       shell: bash
-      run: echo "name=RELEASE_VERSION::canary" >> $GITHUB_ENV
+      run: echo "RELEASE_VERSION=canary" >> $GITHUB_ENV
 
     - name: Build release
       run: make WASI_SDK=wasi-sdk-${{ matrix.wasi_sdk_version.major }}.${{ matrix.wasi_sdk_version.minor }}
@@ -61,10 +61,10 @@ jobs:
 
     - name: Set the release version
       if: startsWith(github.ref, 'refs/tags/v')
-      run: echo "name=RELEASE_VERSION::${GITHUB_REF/refs\/tags\//}" >> $GITHUB_ENV
+      run: echo "RELEASE_VERSION=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_ENV
     - name: Set the release version
       if: github.ref == 'refs/heads/main'
-      run: echo "name=RELEASE_VERSION::canary" >> $GITHUB_ENV
+      run: echo "RELEASE_VERSION=canary" >> $GITHUB_ENV
 
     - name: Download release assets
       uses: actions/download-artifact@v1

--- a/templates/c/.github/workflows/release.yml
+++ b/templates/c/.github/workflows/release.yml
@@ -29,11 +29,11 @@ jobs:
     - name: Set the release version (tag)
       if: startsWith(github.ref, 'refs/tags/v')
       shell: bash
-      run: echo "name=RELEASE_VERSION::${GITHUB_REF/refs\/tags\//}" >> $GITHUB_ENV
+      run: echo "RELEASE_VERSION=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_ENV
     - name: Set the release version (main)
       if: github.ref == 'refs/heads/main'
       shell: bash
-      run: echo "name=RELEASE_VERSION::canary" >> $GITHUB_ENV
+      run: echo "RELEASE_VERSION=canary" >> $GITHUB_ENV
 
     - name: Build release
       run: make WASI_SDK=wasi-sdk-${{ matrix.wasi_sdk_version.major }}.${{ matrix.wasi_sdk_version.minor }}
@@ -58,10 +58,10 @@ jobs:
 
     - name: Set the release version
       if: startsWith(github.ref, 'refs/tags/v')
-      run: echo "name=RELEASE_VERSION::${GITHUB_REF/refs\/tags\//}" >> $GITHUB_ENV
+      run: echo "RELEASE_VERSION=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_ENV
     - name: Set the release version
       if: github.ref == 'refs/heads/main'
-      run: echo "name=RELEASE_VERSION::canary" >> $GITHUB_ENV
+      run: echo "RELEASE_VERSION=canary" >> $GITHUB_ENV
 
     - name: Download release assets
       uses: actions/download-artifact@v1

--- a/templates/rust/.github/workflows/release.azurecr.yml
+++ b/templates/rust/.github/workflows/release.azurecr.yml
@@ -24,11 +24,11 @@ jobs:
     - name: Set the release version (tag)
       if: startsWith(github.ref, 'refs/tags/v')
       shell: bash
-      run: echo ::set-env name=RELEASE_VERSION::${GITHUB_REF/refs\/tags\//}
+      run: echo "RELEASE_VERSION=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_ENV
     - name: Set the release version (main)
       if: github.ref == 'refs/heads/main'
       shell: bash
-      run: echo ::set-env name=RELEASE_VERSION::canary
+      run: echo "RELEASE_VERSION=canary" >> $GITHUB_ENV
 
     - name: Build release
       run: cargo build --verbose --target wasm32-wasi --release
@@ -53,10 +53,10 @@ jobs:
 
     - name: Set the release version
       if: startsWith(github.ref, 'refs/tags/v')
-      run: echo ::set-env name=RELEASE_VERSION::${GITHUB_REF/refs\/tags\//}
+      run: echo "RELEASE_VERSION=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_ENV
     - name: Set the release version
       if: github.ref == 'refs/heads/main'
-      run: echo ::set-env name=RELEASE_VERSION::canary
+      run: echo "RELEASE_VERSION=canary" >> $GITHUB_ENV
 
     - name: Download release assets
       uses: actions/download-artifact@v1

--- a/templates/rust/.github/workflows/release.yml
+++ b/templates/rust/.github/workflows/release.yml
@@ -21,11 +21,11 @@ jobs:
     - name: Set the release version (tag)
       if: startsWith(github.ref, 'refs/tags/v')
       shell: bash
-      run: echo ::set-env name=RELEASE_VERSION::${GITHUB_REF/refs\/tags\//}
+      run: echo "RELEASE_VERSION=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_ENV
     - name: Set the release version (main)
       if: github.ref == 'refs/heads/main'
       shell: bash
-      run: echo ::set-env name=RELEASE_VERSION::canary
+      run: echo "RELEASE_VERSION=canary" >> $GITHUB_ENV
 
     - name: Build release
       run: cargo build --verbose --target wasm32-wasi --release
@@ -50,10 +50,10 @@ jobs:
 
     - name: Set the release version
       if: startsWith(github.ref, 'refs/tags/v')
-      run: echo ::set-env name=RELEASE_VERSION::${GITHUB_REF/refs\/tags\//}
+      run: echo "RELEASE_VERSION=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_ENV
     - name: Set the release version
       if: github.ref == 'refs/heads/main'
-      run: echo ::set-env name=RELEASE_VERSION::canary
+      run: echo "RELEASE_VERSION=canary" >> $GITHUB_ENV
 
     - name: Download release assets
       uses: actions/download-artifact@v1


### PR DESCRIPTION
GitHub deprecated the `::set-env` command in workflows.  The C and AssemblyScript workflows had removed this but in a way that was broken; the Rust workflows hadn't removed it at all.  This PR fixes them all so that everything is now perfect.  PERFECT.