### PR TITLE
added instructions for npm install

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ First, install [Yeoman](http://yeoman.io) using [npm](https://www.npmjs.com/) (w
 npm install -g yo
 # npm install -g generator-wasm-oci
 # for now do instead:
-npm run compile && npm link
+npm install && npm run compile && npm link
 ```
 
 Then generate your new project:

--- a/README.md
+++ b/README.md
@@ -23,8 +23,10 @@ npm install && npm run compile && npm link
 
 Then generate your new project:
 
-```bash
-yo wasm-oci
+```console
+$ mkdir myproject
+$ cd myproject
+$ yo wasm-oci
 ```
 
 ## Setting up a project


### PR DESCRIPTION
A minor change to the README to run `npm install` on the repo before doing the compile. I needed to do this in order to get it working.

Signed-off-by: Matt Butcher <matt.butcher@microsoft.com>