### PR TITLE
Rename to generator-wasm

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -27,5 +27,5 @@ jobs:
     - name: Save package artifact
       uses: actions/upload-artifact@v2
       with:
-        name: generator-wasm-oci
-        path: generator-wasm-oci-*.tgz
+        name: generator-wasm
+        path: generator-wasm-*.tgz

--- a/README.md
+++ b/README.md
@@ -1,22 +1,22 @@
-# generator-wasm-oci [![NPM version][npm-image]][npm-url] [![Build Status][travis-image]][travis-url] [![Dependency Status][daviddm-image]][daviddm-url]
+# generator-wasm [![NPM version][npm-image]][npm-url] [![Build Status][travis-image]][travis-url] [![Dependency Status][daviddm-image]][daviddm-url]
 
 Generate WASM modules that can be pushed to OCI registries, for example
 for use with [Krustlet](https://github.com/deislabs/krustlet).
 
 **This generator is currently work in progress.  You cannot yet install it using npm.**
 If you would like to try it, you can clone
-the repo and run `npm run compile && npm link` to hook it up to Yeoman so that you can run `yo wasm-oci`.
+the repo and run `npm run compile && npm link` to hook it up to Yeoman so that you can run `yo wasm`.
 Or let us know so that we're motivated to get it ready for a proper release!
 
 ## Installation
 
 First, install [Yeoman](http://yeoman.io) using [npm](https://www.npmjs.com/) (we assume you have pre-installed [node.js](https://nodejs.org/)).
 
-**NOTE: You can't install `generator-wasm-oci` using `npm install` yet - for now you need to run `npm run compile && npm link` as described above.**  ~~Then install `generator-wasm-oci` also using `npm`.~~
+**NOTE: You can't install `generator-wasm` using `npm install` yet - for now you need to run `npm run compile && npm link` as described above.**  ~~Then install `generator-wasm` also using `npm`.~~
 
 ```bash
 npm install -g yo
-# npm install -g generator-wasm-oci
+# npm install -g generator-wasm
 # for now do instead:
 npm install && npm run compile && npm link
 ```
@@ -26,7 +26,7 @@ Then generate your new project:
 ```console
 $ mkdir myproject
 $ cd myproject
-$ yo wasm-oci
+$ yo wasm
 ```
 
 ## Setting up a project
@@ -90,9 +90,9 @@ For more information see the [Code of Conduct
 FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact
 [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.
 
-[npm-image]: https://badge.fury.io/js/generator-wasm-oci.svg
-[npm-url]: https://npmjs.org/package/generator-wasm-oci
-[travis-image]: https://travis-ci.com/deislabs/generator-wasm-oci.svg?branch=master
-[travis-url]: https://travis-ci.com/deislabs/generator-wasm-oci
-[daviddm-image]: https://david-dm.org/deislabs/generator-wasm-oci.svg?theme=shields.io
-[daviddm-url]: https://david-dm.org/deislabs/generator-wasm-oci
+[npm-image]: https://badge.fury.io/js/generator-wasm.svg
+[npm-url]: https://npmjs.org/package/generator-wasm
+[travis-image]: https://travis-ci.com/deislabs/generator-wasm.svg?branch=master
+[travis-url]: https://travis-ci.com/deislabs/generator-wasm
+[daviddm-image]: https://david-dm.org/deislabs/generator-wasm.svg?theme=shields.io
+[daviddm-url]: https://david-dm.org/deislabs/generator-wasm

--- a/__tests__/app.js
+++ b/__tests__/app.js
@@ -3,7 +3,7 @@ const path = require('path');
 const assert = require('yeoman-assert');
 const helpers = require('yeoman-test');
 
-describe('generator-wasm-oci:app', () => {
+describe('generator-wasm:app', () => {
   beforeAll(() => {
     return helpers
       .run(path.join(__dirname, '../generators/app'))

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "generator-wasm-oci",
+  "name": "generator-wasm",
   "version": "0.0.1",
   "lockfileVersion": 1,
   "requires": true,

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
-  "name": "generator-wasm-oci",
+  "name": "generator-wasm",
   "version": "0.0.1",
-  "description": "Publish programs as WASM modules via OCI registries",
-  "homepage": "https://github.com/deislabs/generator-wasm-oci",
+  "description": "Publish programs as WASM modules",
+  "homepage": "https://github.com/deislabs/generator-wasm",
   "author": {
     "name": "itowlson",
     "email": "ivan.towlson@microsoft.com"

--- a/templates/assembly-script/.github/workflows/release.nopublish.yml
+++ b/templates/assembly-script/.github/workflows/release.nopublish.yml
@@ -1,0 +1,41 @@
+name: release
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - "v*"
+
+jobs:
+  build:
+    name: Build release assets
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Setup Node.js
+      uses: actions/setup-node@v1
+      with:
+        node-version: 12
+
+    - name: Set the release version (tag)
+      if: startsWith(github.ref, 'refs/tags/v')
+      shell: bash
+      run: echo "RELEASE_VERSION=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_ENV
+    - name: Set the release version (main)
+      if: github.ref == 'refs/heads/main'
+      shell: bash
+      run: echo "RELEASE_VERSION=canary" >> $GITHUB_ENV
+
+    - name: Build release
+      run: |
+        npm install
+        npm run build
+
+    - name: Upload artifact
+      uses: actions/upload-artifact@v1
+      with:
+        name: <%= moduleName %>.wasm
+        path: build/optimized.wasm

--- a/templates/c/.github/workflows/release.nopublish.yml
+++ b/templates/c/.github/workflows/release.nopublish.yml
@@ -1,0 +1,45 @@
+name: release
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - "v*"
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        wasi_sdk_version:
+        - major: 11
+          minor: 0
+
+    name: Build release assets
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Install clang bits
+      run: |
+        wget https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-${{ matrix.wasi_sdk_version.major }}/wasi-sdk-${{ matrix.wasi_sdk_version.major }}.${{ matrix.wasi_sdk_version.minor }}-linux.tar.gz
+        tar xvf wasi-sdk-${{ matrix.wasi_sdk_version.major }}.${{ matrix.wasi_sdk_version.minor }}-linux.tar.gz
+
+    - name: Set the release version (tag)
+      if: startsWith(github.ref, 'refs/tags/v')
+      shell: bash
+      run: echo "RELEASE_VERSION=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_ENV
+    - name: Set the release version (main)
+      if: github.ref == 'refs/heads/main'
+      shell: bash
+      run: echo "RELEASE_VERSION=canary" >> $GITHUB_ENV
+
+    - name: Build release
+      run: make WASI_SDK=wasi-sdk-${{ matrix.wasi_sdk_version.major }}.${{ matrix.wasi_sdk_version.minor }}
+
+    - name: Upload artifact
+      uses: actions/upload-artifact@v1
+      with:
+        name: <%= moduleName %>.wasm
+        path: ./<%= moduleName %>.wasm

--- a/templates/rust/.github/workflows/release.nopublish.yml
+++ b/templates/rust/.github/workflows/release.nopublish.yml
@@ -1,0 +1,37 @@
+name: release
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - "v*"
+
+jobs:
+  build:
+    name: Build release assets
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Install Rust bits
+      run: rustup target add wasm32-wasi
+
+    - name: Set the release version (tag)
+      if: startsWith(github.ref, 'refs/tags/v')
+      shell: bash
+      run: echo "RELEASE_VERSION=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_ENV
+    - name: Set the release version (main)
+      if: github.ref == 'refs/heads/main'
+      shell: bash
+      run: echo "RELEASE_VERSION=canary" >> $GITHUB_ENV
+
+    - name: Build release
+      run: cargo build --verbose --target wasm32-wasi --release
+
+    - name: Upload artifact
+      uses: actions/upload-artifact@v1
+      with:
+        name: <%= moduleName %>.wasm
+        path: target/wasm32-wasi/release/<%= moduleName %>.wasm

--- a/ts/generators/app/index.ts
+++ b/ts/generators/app/index.ts
@@ -4,13 +4,16 @@ import * as fspath from 'path';
 
 import { Registry } from './providers/registry';
 import { acr } from './providers/acr';
-import { defaultRegistry } from './providers/default';
+import { noRegistry } from './providers/none';
 
 import { Language } from './languages/language';
 import { rust } from './languages/rust';
 import { clang } from './languages/c';
 import { assemblyScript } from './languages/assembly-script';
 import { failed } from './utils/errorable';
+
+const REGISTRY_CHOICE_ACR = "Azure Container Registry";
+const REGISTRY_CHOICE_NONE = "I don't want to publish to an OCI registry";
 
 module.exports = class extends Generator {
   private answers: any = undefined;
@@ -56,7 +59,8 @@ module.exports = class extends Generator {
         name: 'registryProvider',
         message: 'What registry provider do you plan to publish the module to?',
         choices: [
-          'Azure Container Registry'
+          REGISTRY_CHOICE_ACR,
+          REGISTRY_CHOICE_NONE
         ],
         default: 'Azure Container Registry'
       }
@@ -136,10 +140,12 @@ module.exports = class extends Generator {
 
 function provider(registryProvider: string): Registry {
   switch (registryProvider) {
-    case 'Azure Container Registry':
+    case REGISTRY_CHOICE_ACR:
       return acr;
+    case REGISTRY_CHOICE_NONE:
+      return noRegistry;
     default:
-      return defaultRegistry;
+      return noRegistry;
   }
 }
 

--- a/ts/generators/app/providers/none.ts
+++ b/ts/generators/app/providers/none.ts
@@ -1,7 +1,7 @@
 import Generator = require('yeoman-generator');
 
-export const defaultRegistry = {
+export const noRegistry = {
   prompts(): Generator.Questions<any> { return []; },
   instructions(): ReadonlyArray<string> { return []; },
-  releaseTemplate(): string { return 'release.yml'; }
+  releaseTemplate(): string { return 'release.nopublish.yml'; }
 }


### PR DESCRIPTION
After discussion I'm suggesting we go with `generator-wasm` (hence `yo wasm`) because longer term we are not restricted to WASI templates or to OCI registries.

In accordance with this I've added a "I don't want to publish to an OCI registry" option.

If this is accepted I will rename the repo and change the relevant bits of `package.json` to point to the new repo.